### PR TITLE
Fixed: Use of map-markers produces an error 500 in chatbot IU.

### DIFF
--- a/webapp/app/views/chat_statements/widgets/_interactive_map.html.erb
+++ b/webapp/app/views/chat_statements/widgets/_interactive_map.html.erb
@@ -1,6 +1,6 @@
 <% if interactive_map.params['endpoint'] == 'javascript' %>
   <script>
-    App.Statement.display_js_map("<%= map.params['api_key'] %>", "<%= statement.id %>", <%= interactive_map.params['payload'].to_json.html_safe %>)
+    App.Statement.display_js_map("<%= interactive_map.params['api_key'] %>", "<%= statement.id %>", <%= interactive_map.params['payload'].to_json.html_safe %>)
   </script>
 <% end %>
 


### PR DESCRIPTION
Use of map-markers produces an error 500 in chatbot IU.
To reproduice, use ping-pong bot and try to display a "map-markers".