### PR TITLE
Allow Matomo tracking

### DIFF
--- a/webapp/app/views/layouts/_matomo.html.erb
+++ b/webapp/app/views/layouts/_matomo.html.erb
@@ -1,0 +1,27 @@
+<script>
+  var _paq = window._paq || [];
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="<%= ENV['VIKYAPP_MATOMO_TRACKER_URL'] %>";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '<%= ENV['VIKYAPP_MATOMO_SITE_ID'] %>']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src='//cdn.matomo.cloud/vikyai.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+  (function() {
+    var previousPageUrl = null;
+    addEventListener('turbolinks:load', function(event) {
+      if (previousPageUrl) {
+        _paq.push(['setReferrerUrl', previousPageUrl]);
+        _paq.push(['setCustomUrl', window.location.href]);
+        _paq.push(['setDocumentTitle', document.title]);
+        if (event.data && event.data.timing) {
+          _paq.push(['setGenerationTimeMs', event.data.timing.visitEnd - event.data.timing.visitStart]);
+        }
+        _paq.push(['trackPageView']);
+      }
+      previousPageUrl = window.location.href;
+    });
+  })();
+</script>

--- a/webapp/app/views/layouts/application.html.erb
+++ b/webapp/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <%= stylesheet_link_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <% if Feature.matomo_enabled? %><%= render 'layouts/matomo' %><% end %>
   </head>
 
   <body data-controller-name="<%= controller_path %>"

--- a/webapp/app/views/layouts/devise.html.erb
+++ b/webapp/app/views/layouts/devise.html.erb
@@ -26,6 +26,7 @@
     <%= stylesheet_link_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <% if Feature.matomo_enabled? %><%= render 'layouts/matomo' %><% end %>
   </head>
   <body>
     <div class="login-wrapper">

--- a/webapp/app/views/layouts/errors.html.erb
+++ b/webapp/app/views/layouts/errors.html.erb
@@ -8,6 +8,7 @@
     <%= stylesheet_link_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'errors', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'errors', 'data-turbolinks-track': 'reload' %>
+    <% if Feature.matomo_enabled? %><%= render 'layouts/matomo' %><% end %>
   </head>
 
   <body>

--- a/webapp/doc/matomo.md
+++ b/webapp/doc/matomo.md
@@ -1,0 +1,14 @@
+# Matomo
+
+To enable pages tracking using [Matomo](https://matomo.org/), you must define the following environment variables:
+
+* `VIKYAPP_MATOMO_ENABLED`: boolean.
+* `VIKYAPP_MATOMO_TRACKER_URL`: Matomo tracker URL.
+* `VIKYAPP_MATOMO_SITE_ID`: Matomo site ID.
+
+For example:
+
+    # Enabled Matomo pages tracking
+    VIKYAPP_MATOMO_ENABLED=true
+    VIKYAPP_MATOMO_TRACKER_URL=https://yourvikyai.matomo.cloud/
+    VIKYAPP_MATOMO_SITE_ID=1

--- a/webapp/lib/feature.rb
+++ b/webapp/lib/feature.rb
@@ -12,7 +12,6 @@ module Feature
     ENV['VIKYAPP_USER_REGISTRATION'] = 'false'
   end
 
-
   def self.email_configured?
     return true if Rails.env.test?
 
@@ -20,7 +19,6 @@ module Feature
     postmark_enabled = ENV.fetch("POSTMARK_TOKEN") { false }
     postmark_enabled || smtp_enabled == 'true'
   end
-
 
   def self.quota_enabled?
     ENV['VIKYAPP_QUOTA_ENABLED'] == 'true'
@@ -39,7 +37,6 @@ module Feature
     yield
     disable_quota
   end
-
 
   def self.chatbot_enabled?
     ENV['VIKYAPP_CHATBOT_ENABLED'] == 'true'
@@ -65,8 +62,15 @@ module Feature
     enable_chatbot
   end
 
-
   def self.privacy_policy_enabled?
     !ENV['VIKYAPP_PRIVACY_POLICY_URL'].blank? && !ENV['VIKYAPP_TERMS_OF_USE_URL'].blank?
+  end
+
+  def self.matomo_enabled?
+    (
+      ENV['VIKYAPP_MATOMO_ENABLED'] == 'true' &&
+      !ENV['VIKYAPP_MATOMO_TRACKER_URL'].blank? &&
+      !ENV['VIKYAPP_MATOMO_SITE_ID'].blank?
+    )
   end
 end


### PR DESCRIPTION
Allow Matomo pages tracking via ENV variables. For example:

    # Enabled Matomo pages tracking
    VIKYAPP_MATOMO_ENABLED=true
    VIKYAPP_MATOMO_TRACKER_URL=https://yourvikyai.matomo.cloud/
    VIKYAPP_MATOMO_SITE_ID=1