### PR TITLE
Use logger in jobs instead of Sidekiq::Logging

### DIFF
--- a/webapp/app/jobs/bot_send_start_job.rb
+++ b/webapp/app/jobs/bot_send_start_job.rb
@@ -18,7 +18,7 @@ class BotSendStartJob < ApplicationJob
     Bot.find(bot_id).send_start(chat_session_id, user)
   rescue => e
     backtrace = ::Rails.backtrace_cleaner.clean(e.backtrace)
-    Sidekiq::Logging.logger.error "bot_id:#{bot_id} failed : #{e.message}\n\t#{backtrace.join("\n\t")}"
+    logger.error "bot_id:#{bot_id} failed : #{e.message}\n\t#{backtrace.join("\n\t")}"
     raise
   end
 

--- a/webapp/app/jobs/bot_send_user_statement_job.rb
+++ b/webapp/app/jobs/bot_send_user_statement_job.rb
@@ -35,7 +35,7 @@ class BotSendUserStatementJob < ApplicationJob
   rescue => e
     backtrace = ::Rails.backtrace_cleaner.clean(e.backtrace)
     bot_id = chat_session.bot.id rescue "Unkow bot chat_session_id: #{chat_session_id}"
-    Sidekiq::Logging.logger.error "bot_id:#{chat_session.bot.id} failed : #{e.message}\n\t#{backtrace.join("\n\t")}"
+    logger.error "bot_id:#{chat_session.bot.id} failed: #{e.message}\n\t#{backtrace.join("\n\t")}"
     raise
   end
 


### PR DESCRIPTION
**Description**

Since version 6, sidekiq recommends to use logger instead of Sidekiq::Logging (https://github.com/mperham/sidekiq/wiki/Logging#writing-to-the-log) which doesn't work anymore in our case.

Fix #41.