### PR TITLE
Remove intepreation explanation from the stats

### DIFF
--- a/webapp/app/models/interpret_request_log.rb
+++ b/webapp/app/models/interpret_request_log.rb
@@ -73,13 +73,6 @@ class InterpretRequestLog
   private
 
     def to_json
-
-      # remove explanation
-      body = @body.deep_dup
-      body['interpretations']&.each do |i|
-        i.delete('explanation')
-      end
-
       result = {
         timestamp: @timestamp,
         sentence: @sentence,
@@ -89,10 +82,18 @@ class InterpretRequestLog
         agent_slug: @agents.map(&:slug),
         owner_id: @agents.map { |agent| agent.owner.id },
         status: @status,
-        body: body,
+        body: filter_explanations(@body),
         context: @context.flatten_by_keys(':')
       }
       result[:now] = @now if @now.present?
+      result
+    end
+
+    def filter_explanations(body)
+      result = body.deep_dup
+      result['interpretations']&.each do |i|
+        i.delete('explanation')
+      end
       result
     end
 

--- a/webapp/app/models/interpret_request_log.rb
+++ b/webapp/app/models/interpret_request_log.rb
@@ -26,6 +26,7 @@ class InterpretRequestLog
     @agents ||= Agent.where(id: attributes[:agent_id])
     @sentence ||= ''
     @context ||= {}
+    @body ||= {}
     @context['agent_version'] = @agents.map(&:updated_at)
     @persisted = false
   end
@@ -72,6 +73,13 @@ class InterpretRequestLog
   private
 
     def to_json
+
+      # remove explanation
+      body = @body.deep_dup
+      body['interpretations']&.each do |i|
+        i.delete('explanation')
+      end
+
       result = {
         timestamp: @timestamp,
         sentence: @sentence,
@@ -81,7 +89,7 @@ class InterpretRequestLog
         agent_slug: @agents.map(&:slug),
         owner_id: @agents.map { |agent| agent.owner.id },
         status: @status,
-        body: @body,
+        body: body,
         context: @context.flatten_by_keys(':')
       }
       result[:now] = @now if @now.present?

--- a/webapp/test/controllers/api/v1/nlp_controller_test.rb
+++ b/webapp/test/controllers/api/v1/nlp_controller_test.rb
@@ -229,6 +229,13 @@ class NlsControllerTest < ActionDispatch::IntegrationTest
             'slug'        => 'weather_forecast',
             'score'       => 1.0,
             'explanation' => "a dummy explanation"
+          },
+          {
+            'package'     => agent.id,
+            'id'          => '123456789',
+            'slug'        => 'weather_rainy',
+            'score'       => 1.0,
+            'explanation' => "another explanation"
           }
         ]
       }
@@ -249,6 +256,13 @@ class NlsControllerTest < ActionDispatch::IntegrationTest
           'name'        => 'weather_forecast',
           'score'       => 1.0,
           'explanation' => 'a dummy explanation'
+        },
+        {
+          'id'          => '123456789',
+          'slug'        => 'weather_rainy',
+          'name'        => 'weather_rainy',
+          'score'       => 1.0,
+          'explanation' => 'another explanation'
         }
       ]
     }
@@ -262,6 +276,8 @@ class NlsControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil found[:body]['interpretations']
     assert_not_nil found[:body]['interpretations'].first
     assert_nil     found[:body]['interpretations'].first['explanation']
+    assert_not_nil found[:body]['interpretations'].second
+    assert_nil     found[:body]['interpretations'].second['explanation']
   end
 
   test 'Set spellchecking' do


### PR DESCRIPTION
**Description**

Fix #51

We do not needs explanation in stats (verbose), removing them will reduce the size of the stats (an explanation can weight several Kb)

**Checklist**
- [X] Your code should contain tests relevant for the problem you are solving
- [X] All new and existing tests passed