### PR TITLE
Add linguist config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,19 @@
 CHANGELOG.md merge=union
+
+*.h linguist-language=C
+*.sql linguist-language=SQL
+*.tpl linguist-detectable=false
+*.xsl linguist-detectable=false
+
+nlp/sources/ogm_uni/lib/cjkpunct.c linguist-generated=true
+nlp/sources/ogm_uni/lib/cp1250.c linguist-generated=true
+nlp/sources/ogm_uni/lib/cp1251.c linguist-generated=true
+nlp/sources/ogm_uni/lib/cp1252.c linguist-generated=true
+nlp/sources/ogm_uni/lib/cp1256.c linguist-generated=true
+nlp/sources/ogm_uni/lib/cp850.c linguist-generated=true
+nlp/sources/ogm_uni/lib/cp866.c linguist-generated=true
+nlp/sources/ogm_uni/lib/cp8859_2.c linguist-generated=true
+nlp/sources/ogm_uni/lib/cp8859_5.c linguist-generated=true
+nlp/sources/ogm_uni/lib/cp936.h linguist-generated=true
+nlp/sources/ogm_uni/lib/cpbig5.h linguist-generated=true
+nlp/sources/ogm_uni/lib/cpgb2312.h linguist-generated=true


### PR DESCRIPTION
Improve repository's language stats (https://github.com/github/linguist)

Before

```
47.54%  C
23.36%  Objective-C
15.88%  Ruby
7.38%   HTML
1.73%   CSS
1.39%   CoffeeScript
1.38%   Perl
0.37%   TSQL
0.29%   Smarty
0.25%   Shell
0.18%   JavaScript
0.16%   Dockerfile
0.06%   C++
0.02%   XSLT
```

After

```
61.70%  C
21.46%  Ruby
9.97%   HTML
2.34%   CSS
1.87%   CoffeeScript
1.86%   Perl
0.34%   Shell
0.24%   JavaScript
0.21%   Dockerfile
```