### PR TITLE
Bug/84 selenium exception

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,13 @@ build_nlp:
     - docker_build ${DOCKER_IMAGE_NLP}_test nlp "--target test_image"
 
 # Test
+## Pin Selenium container version embedding Chrome < 83 because of shared-memory option regression
+## see : https://stackoverflow.com/questions/62030026/chrome-83-started-crashing-since-upgrade
+## and shared-memory (/dev/shm) cannot be customize in our current Gitlab + Helm pipeline
+## If you want to try it on your machine just run :
+##  $ docker run --rm --name selenium -d -p 4444:4444 selenium/standalone-chrome:3.141.59-20200515
+##  $ export SELENIUM_REMOTE_URL="http://localhost:4444/wd/hub/"
+##  $ ./bin/rails test:system
 test_webapp:
   extends: .kubernetes_runner
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,7 @@ test_webapp:
   services:
     - postgres:11.5-alpine
     - redis:5.0-alpine
-    - name: selenium/standalone-chrome:3.141.59
+    - name: selenium/standalone-chrome:3.141.59-20200515
       alias: selenium-chrome
     - name: docker.elastic.co/elasticsearch/elasticsearch:7.4.1
       # Important other wise, port 9200 will never be exposed

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,8 +23,6 @@ before_script:
 .kubernetes_runner:
   tags:
     - kubernetes
-  variables:
-    CI_SERVICE_HOST: "127.0.0.1"
 
 # Build docker image
 build_backup:
@@ -85,11 +83,11 @@ test_webapp:
   script:
     - export VIKYAPP_DB_USERNAME="${POSTGRES_USER}"
     - export VIKYAPP_DB_PASSWORD="${POSTGRES_PASSWORD}"
-    - export VIKYAPP_DB_HOST="${CI_SERVICE_HOST:-postgres}"
-    - export VIKYAPP_ACTIONCABLE_REDIS_URL="redis://${CI_SERVICE_HOST:-redis}:6379/1"
-    - export VIKYAPP_ACTIVEJOB_REDIS_URL="redis://${CI_SERVICE_HOST:-redis}:6379/2"
-    - export VIKYAPP_STATISTICS_URL="http://${CI_SERVICE_HOST:-elasticsearch}:9200"
-    - export SELENIUM_REMOTE_URL="http://${CI_SERVICE_HOST:-selenium-chrome}:4444/wd/hub/"
+    - export VIKYAPP_DB_HOST="postgres"
+    - export VIKYAPP_ACTIONCABLE_REDIS_URL="redis://redis:6379/1"
+    - export VIKYAPP_ACTIVEJOB_REDIS_URL="redis://redis:6379/2"
+    - export VIKYAPP_STATISTICS_URL="http://elasticsearch:9200"
+    - export SELENIUM_REMOTE_URL="http://selenium-chrome:4444/wd/hub/"
     - export VIKYAPP_STATISTICS_NO_REPLICA="true"
     - cd /webapp
     - if [ "${SKIP_TEST:-false}" != "true" ] ; then ./bin/docker_run_test.sh ; fi
@@ -109,7 +107,7 @@ test_nlp:
   variables:
     GIT_STRATEGY: none
   script:
-    - export VIKYAPP_REDIS_PACKAGE_NOTIFIER="redis://${CI_SERVICE_HOST:-redis}:6379/3"
+    - export VIKYAPP_REDIS_PACKAGE_NOTIFIER="redis://redis:6379/3"
     - if [ "${SKIP_TEST:-false}" != "true" ] ; then /docker_run_test.sh ; fi
   artifacts:
     # expire_in: 1 week

--- a/webapp/test/application_system_test_case.rb
+++ b/webapp/test/application_system_test_case.rb
@@ -7,8 +7,9 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   Capybara.register_driver(:headless_chrome) do |app|
     options = Selenium::WebDriver::Chrome::Options.new
-    options.add_argument 'no-sandbox'
-    options.add_argument 'disable-dev-shm-usage'
+    options.add_argument '--no-sandbox'
+    options.add_argument '--disable-dev-shm-usage'
+    options.add_argument '--disable-gpu'
     options.headless!
     driver_options = { browser: :chrome, options: options }
     driver_options[:url] = ENV['SELENIUM_REMOTE_URL'] if ENV['SELENIUM_REMOTE_URL']


### PR DESCRIPTION
**Description**

Fix #84 

Basically the Selenium container update the Chrome version but keep the same Docker version tag.
Unfortunately, Chrome 83 contains a regression where the `disable-dev-shm-usage` does not work anymore.
The solution for now is to use a previous version of the Selenium container embedding Chrome 81.
